### PR TITLE
Fixes duplicate folders showing up after saving files

### DIFF
--- a/gitusers/views.py
+++ b/gitusers/views.py
@@ -304,7 +304,15 @@ class RepositoryCreateFileView(OwnerRequiredMixin, FormView):
 
 	def get_initial(self, **kwargs):
 		initial = super(RepositoryCreateFileView, self).get_initial()
-		initial['filename'] = '.html'
+		directory = ""
+		if 'directories' in self.kwargs:
+			directory = self.kwargs['directories']
+		if 'directories_ext' in self.kwargs:
+			directory += "/" + self.kwargs['directories_ext']
+		if directory != "":
+			initial['filename'] = directory + '/.html'
+		else:
+			initial['filename'] = '.html'
 		return initial
 
 	def form_valid(self, form):
@@ -617,8 +625,11 @@ class BlobDeleteFolderView(DeleteView):
 		print('directory.split("/")', directory.split("/"))
 		folders = directory.split("/")
 		for folder in folders:
-			item = tree.__getitem__(str(folder))
-			index_tree.read_tree(item.id)
+			try:
+				item = tree.__getitem__(str(folder))
+				index_tree.read_tree(item.id)
+			except:
+				pass
 		blob_id = find_file_oid_in_tree_using_index(filename, index_tree)
 		print('index_tree.__contains__(filename)', index_tree.__contains__(filename))
 		# index_tree.remove(str(filename))

--- a/gitusers/viewsets.py
+++ b/gitusers/viewsets.py
@@ -85,6 +85,7 @@ class FilesView(APIView):
         try:
             commit = this_repo.revparse_single('HEAD')
             tree = commit.tree
+            folders = []
             if directory != "":
                 item = tree.__getitem__(str(directory))
                 index_tree.read_tree(item.id)
@@ -96,19 +97,25 @@ class FilesView(APIView):
                     type = ""
                     if filemode is '33188':
                         type = "tree"
+                        if name in folders:
+                            continue
+                        folders.append(name)
                     else:
                         type = "blob"
                     if "/" in entry.path:
                         name = entry.path.split("/")[0]
                         filemode = '100644'
                         type = "tree"
-
+                        if name in folders:
+                            continue
+                        folders.append(name)
 
 
                     tuplet.append({'name': name, 'id': entry.hex, 'type': type, 'filemode': filemode})
             else:
                 for entry in tree:
                     tuplet.append({'name': entry.name, 'id': entry.id.hex, 'type': entry.type, 'filemode': entry.filemode})
+            print('folders', folders)
             date_handler = lambda obj: (
                 obj.isoformat()
                 if isinstance(obj, (datetime.datetime, datetime.date))


### PR DESCRIPTION
Initializes the "new file" output to be the folder you're in currently. Also as a result of this creation it causes multiple folders to show up in the apiview, probably something related to index creation, so I nixed that with a check of folder names existing under the apiview.