### PR TITLE
Changes repo dir

### DIFF
--- a/django_git/settings.py
+++ b/django_git/settings.py
@@ -146,7 +146,7 @@ MEDIA_URL = "/media/"
 
 
 # Pygit2 settings
-REPO_DIR = os.path.join(BASE_DIR, "git_repos")
+REPO_DIR = os.path.join(BASE_DIR, "media", "git_repos")
 '''
 if not path.exists(GITS_DIR):
     os.makedirs(GITS_DIR)


### PR DESCRIPTION
This changes the repo_dir from root of folder to /media/, as requested by James.

Please note this will break old versions of your django_git_tinymce. The easiest thing to do is just drag git_repos into /media/.

